### PR TITLE
fix(deploy): add N8N_HEALTH_URL to Cloud Run deploy env vars

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,7 +58,7 @@ jobs:
             --region=${{ env.REGION }} \
             --platform=managed \
             --allow-unauthenticated \
-            --set-env-vars="MODE=prod,DISCORD_PUBLIC_KEY=${{ secrets.DISCORD_PUBLIC_KEY }},DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }},DISCORD_APPLICATION_ID=${{ secrets.DISCORD_APPLICATION_ID }},DISCORD_GUILD_ID=${{ secrets.DISCORD_GUILD_ID }}" \
+            --set-env-vars="MODE=prod,DISCORD_PUBLIC_KEY=${{ secrets.DISCORD_PUBLIC_KEY }},DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }},DISCORD_APPLICATION_ID=${{ secrets.DISCORD_APPLICATION_ID }},DISCORD_GUILD_ID=${{ secrets.DISCORD_GUILD_ID }},N8N_HEALTH_URL=${{ secrets.N8N_HEALTH_URL }}" \
             --port=8000
 
       - name: Get service URL


### PR DESCRIPTION
## Summary

- デプロイ時に `N8N_HEALTH_URL` が Cloud Run に渡されておらず、起動時に pydantic `ValidationError` が発生していた
- `--set-env-vars` は既存の環境変数を**全上書き**するため、リストに含まれない変数は削除される
- `N8N_HEALTH_URL=${{ secrets.N8N_HEALTH_URL }}` を追加して修正

## 事前作業

GitHub Secrets に `N8N_HEALTH_URL` を追加してください（値: `https://n8n.u-rei.com/healthz`）

## Test plan

- [x] GitHub Secrets に `N8N_HEALTH_URL` を追加する
- [x] workflow_dispatch で手動実行にてデプロイ成功を確認した ~~このPRをマージしてリリースを再作成し、デプロイが成功することを確認する~~

🤖 Generated with [Claude Code](https://claude.com/claude-code)
